### PR TITLE
Fix build errors that occurr when targeting C++20

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -341,37 +341,39 @@ Napi::Object verifySignature(const Napi::CallbackInfo &info)
   {
     goto Cleanup;
   }
-
-  CRYPT_PROVIDER_DATA *pProvData = WTHelperProvDataFromStateData(WinTrustData.hWVTStateData);
-  if (NULL == pProvData)
-  {
-    result.Set("signed", false);
-    result.Set("message", "pProvData is null");
-    goto Cleanup;
-  }
-
-  //
-  // Get the signer
-  //
-
-  CRYPT_PROVIDER_SGNR *pProvSigner = WTHelperGetProvSignerFromChain(pProvData, 0, FALSE, 0);
-  if (NULL == pProvSigner)
-  {
-    result.Set("signed", false);
-    result.Set("message", "pProvSigner is null");
-    goto Cleanup;
-  }
-
-  signSubject = GetSignSubjectInfo(pProvSigner->pChainContext);
-  if (signSubject.empty())
-  {
-    result.Set("signed", false);
-    result.Set("message", "sign subject info is empty");
-    goto Cleanup;
-  }
   else
   {
-    result.Set("subject", WStringToString(signSubject));
+    CRYPT_PROVIDER_DATA *pProvData = WTHelperProvDataFromStateData(WinTrustData.hWVTStateData);
+    if (NULL == pProvData)
+    {
+      result.Set("signed", false);
+      result.Set("message", "pProvData is null");
+      goto Cleanup;
+    }
+
+    //
+    // Get the signer
+    //
+
+    CRYPT_PROVIDER_SGNR *pProvSigner = WTHelperGetProvSignerFromChain(pProvData, 0, FALSE, 0);
+    if (NULL == pProvSigner)
+    {
+      result.Set("signed", false);
+      result.Set("message", "pProvSigner is null");
+      goto Cleanup;
+    }
+
+    signSubject = GetSignSubjectInfo(pProvSigner->pChainContext);
+    if (signSubject.empty())
+    {
+      result.Set("signed", false);
+      result.Set("message", "sign subject info is empty");
+      goto Cleanup;
+    }
+    else
+    {
+      result.Set("subject", WStringToString(signSubject));
+    }
   }
 
 Cleanup:


### PR DESCRIPTION
When this module is compiled, on Windows, against C++20, the below errors occurr:

```
npm error main.cc
npm error C:\repos\win-verify-signature\src\main.cc(357,24): error C2362: initialization of 'pProvSigner' is skipped by 'goto Cleanup' [C:\repos\win-verify-signature\build\win-verify-signature.vcxproj]
npm error       C:\repos\win-verify-signature\src\main.cc(377,1):
npm error       see declaration of 'Cleanup'
npm error
npm error C:\repos\win-verify-signature\src\main.cc(345,24): error C2362: initialization of 'pProvData' is skipped by 'goto Cleanup' [C:\repos\win-verify-signature\build\win-verify-signature.vcxproj]
npm error       C:\repos\win-verify-signature\src\main.cc(377,1):
npm error       see declaration of 'Cleanup'
```

These errors can be resolved by making the changes in this pull request.